### PR TITLE
Add "password_confirmation" to list of ignored input fields

### DIFF
--- a/config/laravel_log_enhancer.php
+++ b/config/laravel_log_enhancer.php
@@ -14,5 +14,5 @@ return [
     'log_git_data' => false,
 
     // You can specify the inputs from the user that should not be logged
-    'ignore_input_fields' => ['password', 'confirm_password'],
+    'ignore_input_fields' => ['password', 'confirm_password', 'password_confirmation'],
 ];


### PR DESCRIPTION
Hi.

The default naming for fields validated with the "confirmed" rule in Laravel is `foo_confirmation` ([ref](https://laravel.com/docs/5.7/validation#rule-confirmed)) so I think it would make sense to add `password_confirmation` to the list of fields ignored by default.