### PR TITLE
Allow for minor versions of monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": ">=7.1.3",
         "illuminate/support": "5.6.*|5.7.*",
-        "monolog/monolog": "1.23.*"
+        "monolog/monolog": "^1.23"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
This would allow all minor versions of monolog from 1.23 going forward.