### PR TITLE
Add support for Laravel 9.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4, 7.3]
+                php: [8.1, 8.0, 7.4, 7.3]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2022-02-10
+### Added
+- Support for Laravel 9.x
+
 ## [1.3.1] - 2020-12-01
 ### Added
 - Support for PHP 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.0] - 2022-02-10
+## [1.4.0] - 2022-02-15
 ### Added
-- Support for Laravel 9.x
+- Support for Laravel 9.x and PHP 8.1
 
 ## [1.3.1] - 2020-12-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![StyleCI](https://styleci.io/repos/126970369/shield?branch=master)](https://styleci.io/repos/126970369)
 [![Buy us a tree](https://img.shields.io/badge/Buy%20me%20a%20tree-%F0%9F%8C%B3-lightgreen?style=flat-square)](https://plant.treeware.earth/freshbitsweb/laravel-log-enhancer)
 
-# Laravel Log Enhancer (Laravel 5.6 to Laravel 8.x)
+# Laravel Log Enhancer (Laravel 5.6 to Laravel 9.x)
 Laravel's logging system helps a lot for storing data as well as while troubleshooting some hidden bugs. The data related to the exception automatically gets logged whenever something goes wrong.
 
 Sometimes, we need more than just *stack trace* to debug the issue easily. The things like **request URL**, **request input data**, **session data**, etc. help us hunt down the exact cause quickly. That's what this *plug-and-play* Laravel package does for you :)
@@ -12,6 +12,7 @@ Sometimes, we need more than just *stack trace* to debug the issue easily. The t
 ## Requirements
 | PHP    | Laravel | Package |
 |--------|---------|---------|
+| 8.0+   | 9.x     | v1.4.0  |
 | 7.3+   | 8.x     | v1.3.0  |
 | 7.2.5+ | 7.x     | v1.2.0  |
 | <7.2.5 | 6.x     | v1.1.0  |

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3.9",
-        "orchestra/testbench": "^6.0.0|^7.0.0"
+        "orchestra/testbench": "^6.23.0|^7.0.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "Make debugging easier by adding more data to your laravel logs",
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0",
         "monolog/monolog": "^1.23|^2.1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3.9",
-        "orchestra/testbench": "^6.0.0"
+        "orchestra/testbench": "^6.0.0|^7.0.0"
     },
     "license": "MIT",
     "authors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
          verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+>
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="League Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
@gauravmak I've made the changes to support the newest major version of Laravel. While running tests locally I was prompted to update `phpunit.xml` to the new standard format, so I did that too.

Also updated the Action to include testing for PHP 8.1